### PR TITLE
add missing dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "main": "lib/index.js",
   "devDependencies": {
     "babel-cli": "^6.9.0",
+    "babel-core": "^6.11.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "^6.11.6",
     "mocha": "^2.4.5"
   },
   "scripts": {


### PR DESCRIPTION
`babel-core` and `babel-register` were both missing from the dependencies list. Adding them in fixes it.

Would be good to add a travis build.
